### PR TITLE
Sales Returns: align refund_method with DB enum; show error summary on create form

### DIFF
--- a/app/Http/Controllers/Tenant/Sales/ReturnController.php
+++ b/app/Http/Controllers/Tenant/Sales/ReturnController.php
@@ -174,7 +174,8 @@ class ReturnController extends Controller
             'type' => 'required|in:return,exchange',
             'reason' => 'required|string',
             'notes' => 'nullable|string',
-            'refund_method' => 'nullable|string|in:cash,credit,bank_transfer',
+            // Match DB enum in this environment: cash, bank_transfer, credit_note, exchange
+            'refund_method' => 'nullable|string|in:cash,bank_transfer,credit_note,exchange',
             'return_scope' => 'nullable|in:full,partial',
             'items' => 'required|array|min:1',
             'items.*.invoice_item_id' => 'required|exists:invoice_items,id',

--- a/resources/views/tenant/sales/returns/create.blade.php
+++ b/resources/views/tenant/sales/returns/create.blade.php
@@ -138,8 +138,9 @@
                 <select name="refund_method" style="width: 100%; padding: 12px; border: 2px solid #e2e8f0; border-radius: 8px;">
                     <option value="">اختر طريقة الاسترداد</option>
                     <option value="cash" {{ old('refund_method') === 'cash' ? 'selected' : '' }}>نقداً</option>
-                    <option value="credit" {{ old('refund_method') === 'credit' ? 'selected' : '' }}>رصيد للعميل</option>
                     <option value="bank_transfer" {{ old('refund_method') === 'bank_transfer' ? 'selected' : '' }}>تحويل بنكي</option>
+                    <option value="credit_note" {{ old('refund_method') === 'credit_note' ? 'selected' : '' }}>رصيد إشعار دائن</option>
+                    <option value="exchange" {{ old('refund_method') === 'exchange' ? 'selected' : '' }}>استبدال</option>
                 </select>
                 @error('refund_method')
                     <div style="color: #f56565; font-size: 14px; margin-top: 5px;">{{ $message }}</div>


### PR DESCRIPTION
This PR aligns the refund_method validation and UI with the DB enum values and adds a top-level error summary on the create form.

Changes:
- Controller: validate refund_method against cash, bank_transfer, credit_note, exchange (matches prod DB enum)
- View: update refund_method select options to same values and labels
- Minor: error summary box at top of form

Why:
- Fixes MySQL warning 1265 "Data truncated for column 'refund_method'" when selecting 'credit'
- Prevents bounce back to create due to enum mismatch

Testing:
- Submit with each method; DB accepts without truncation
- Validation errors appear in summary box


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author